### PR TITLE
Insert `"pypi": "yes"` into `cookiecutter.json`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -16,6 +16,7 @@
     "__entry_point": "testpilot",
     "__github_url": "https://github.com/hypothesis/testpilot",
     "__pypi_url": "https://pypi.org/project/testpilot/",
-    "__copyright_year": "2022"
+    "__copyright_year": "2022",
+    "pypi": "yes"
   }
 }


### PR DESCRIPTION
This is needed to prevent the cookiecutter from removing the PyPI support from this project now that PyPI is optional. See: https://github.com/hypothesis/cookiecutters/pull/104
